### PR TITLE
Ignore case of delimiter command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -183,10 +183,7 @@ function publishStatement (context: SplitExecutionContext): void {
 
 function handleKeyTokenFindResult (context: SplitExecutionContext, findResult: FindExpResult): void {
   // ignore case of delimiter command
-  if (findResult.exp?.trim().toUpperCase() === "DELIMITER") {
-    findResult.exp = "DELIMITER";
-  }
-  switch (findResult.exp?.trim()) {
+  switch (findResult.exp?.trim().toUpperCase()) {
     case context.currentDelimiter:
       read(context, findResult.expIndex, findResult.nextIndex)
       publishStatement(context)

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,7 +182,12 @@ function publishStatement (context: SplitExecutionContext): void {
 }
 
 function handleKeyTokenFindResult (context: SplitExecutionContext, findResult: FindExpResult): void {
-  switch (findResult.exp?.trim()) {
+  let token = findResult.exp?.trim();
+  // ignore case of delimiter command
+  if (token?.toUpperCase() === "DELIMITER") {
+    token = "DELIMITER";
+  }
+  switch (token) {
     case context.currentDelimiter:
       read(context, findResult.expIndex, findResult.nextIndex)
       publishStatement(context)

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,12 +182,11 @@ function publishStatement (context: SplitExecutionContext): void {
 }
 
 function handleKeyTokenFindResult (context: SplitExecutionContext, findResult: FindExpResult): void {
-  let token = findResult.exp?.trim();
   // ignore case of delimiter command
-  if (token?.toUpperCase() === "DELIMITER") {
-    token = "DELIMITER";
+  if (findResult.exp?.trim().toUpperCase() === "DELIMITER") {
+    findResult.exp = "DELIMITER";
   }
-  switch (token) {
+  switch (findResult.exp?.trim()) {
     case context.currentDelimiter:
       read(context, findResult.expIndex, findResult.nextIndex)
       publishStatement(context)

--- a/test/split.test.ts
+++ b/test/split.test.ts
@@ -321,3 +321,23 @@ test('should retain mixed style comments while combine compatible statements cor
     ].join('\n')
   ])
 })
+
+test('should ignore case of statements', t => {
+  const output = split([
+    "delimiter $$",
+    "select 1$$",
+    "dElImitER ;;",
+    "sElEcT 2;;",
+    "DELIMITER ;",
+    "SELECT 3;",
+  ].join('\n'), { multipleStatements: true, retainComments: true })
+  t.deepEqual(output, [
+    [
+      "select 1;",
+      "sElEcT 2;",
+      "SELECT 3;"
+    ].join('\n')
+  ])
+})
+
+


### PR DESCRIPTION
# Description

First of all, thanks for your package! This works great.

I just found that when using delimiter in lowercase or anything that is not exactly `DELIMITER` it was failing.

Added a little patch to detect different casing. Also added a test to check that different casing is actually processed.

